### PR TITLE
Improve edge edit clicking

### DIFF
--- a/force.html
+++ b/force.html
@@ -22,6 +22,8 @@
     .link{stroke:#555;stroke-width:1.5px;fill:none;marker-end:url(#arrow)}
     .link.highlight{stroke:red;stroke-width:3px}
     text{font-size:12px;pointer-events:none;fill:#000}
+    .label{pointer-events:all;cursor:pointer}
+    .link-hit{stroke:transparent;stroke-width:14px;fill:none;cursor:pointer}
     button{cursor:pointer}
     #edgePopup{position:absolute;background:#ffffe0;border:1px solid #aaa;border-radius:4px;padding:4px;font-size:12px;box-shadow:0 2px 4px rgba(0,0,0,0.2);display:none}
     #edgePopup input{width:120px}
@@ -135,9 +137,10 @@ svg.append('defs').append('marker')
 
 const g = svg.append('g');
 const linkGroup = g.append('g').attr('class','links');
-let  linkSel  = linkGroup.selectAll('path');
-let  labelSel = linkGroup.selectAll('text.label');
-let  nodeSel  = g.selectAll('.node');
+let  linkSel     = linkGroup.selectAll('path.link');
+let  linkHitSel  = linkGroup.selectAll('path.link-hit');
+let  labelSel    = linkGroup.selectAll('text.label');
+let  nodeSel     = g.selectAll('.node');
 
 /* ---------- D3 forces ---------- */
 const chargeInput = document.getElementById('chargeRange');
@@ -168,13 +171,16 @@ const simulation = d3.forceSimulation(nodes)
 function ticked(){
   /* ---------- arrow path ---------- */
   const r = 22;                        // node radius
-  linkSel.attr('d', d => {
+  const pathD = d => {
     const dx   = d.target.x - d.source.x,
           dy   = d.target.y - d.source.y,
           dist = Math.hypot(dx, dy) || 1,
           tEnd = (dist - r) / dist;    // line ends at target circle
     return `M${d.source.x},${d.source.y}L${d.source.x + dx*tEnd},${d.source.y + dy*tEnd}`;
-  });
+  };
+
+  linkSel.attr('d', pathD);
+  linkHitSel.attr('d', pathD);
 
   /* keep nodes visible & movable */
   nodeSel.attr('transform', d => `translate(${d.x},${d.y})`);
@@ -315,7 +321,7 @@ function updateGraph(skipSelectUpdate = false, highlightIdx = null) {
   const simLinks = buildSimLinks();
 
   /* ---- links ---- */
-  linkSel = linkGroup.selectAll('path').data(simLinks, (d,i)=>i)
+  linkSel = linkGroup.selectAll('path.link').data(simLinks, (d,i)=>i)
         .join(
                 enter => enter.append('path')
                                           .attr('class','link')
@@ -328,6 +334,15 @@ function updateGraph(skipSelectUpdate = false, highlightIdx = null) {
                                           .attr('stroke-width',1.5)
                                           .attr('marker-end','url(#arrow)')
                                           .on('click', edgeMenu),
+                exit   => exit.remove()
+          );
+
+  linkHitSel = linkGroup.selectAll('path.link-hit').data(simLinks, (d,i)=>i)
+        .join(
+                enter => enter.append('path')
+                                          .attr('class','link-hit')
+                                          .on('click', edgeMenu),
+                update => update.on('click', edgeMenu),
                 exit   => exit.remove()
           );
 
@@ -404,6 +419,7 @@ function edgeMenu(event, d) {
   event.stopPropagation();
   let idx = linkSel.nodes().indexOf(event.currentTarget);
   if (idx === -1) idx = labelSel.nodes().indexOf(event.currentTarget);
+  if (idx === -1) idx = linkHitSel.nodes().indexOf(event.currentTarget);
   if (idx === -1) return;
 
   openEdgePopup(idx, event.pageX, event.pageY);


### PR DESCRIPTION
## Summary
- make edge text clickable by removing pointer-events:none
- create invisible wide path for easier edge clicking
- update edge menu selection logic

## Testing
- `No tests`