### PR TITLE
Adjust node radius by edge count

### DIFF
--- a/force.html
+++ b/force.html
@@ -151,6 +151,8 @@ let  linkHitSel  = linkGroup.selectAll('path.link-hit');
 let  labelSel    = linkGroup.selectAll('text.label');
 let  nodeSel     = g.selectAll('.node');
 
+const BASE_RADIUS = 22;  // radius for nodes with 3 edges
+
 /* ---------- D3 forces ---------- */
 const chargeInput = document.getElementById('chargeRange');
 const linkInput   = document.getElementById('linkRange');
@@ -176,17 +178,17 @@ const simulation = d3.forceSimulation(nodes)
            .strength(() => +chargeRange.value)        // live-updates with slider
            .distanceMax(1_000000))                       // repulse across whole graph
   .force('center', d3.forceCenter(width / 2, height / 2))
-  .force('collision', d3.forceCollide().radius(40))
+  .force('collision', d3.forceCollide().radius(d => (d.r || BASE_RADIUS/3) * 40 / BASE_RADIUS))
   .alphaDecay(0.001)                                  // cools more slowly → runs longer
   .on('tick', ticked);
 
 function ticked(){
   /* ---------- arrow path ---------- */
-  const r = 22;                        // node radius
   const pathD = d => {
     const dx   = d.target.x - d.source.x,
           dy   = d.target.y - d.source.y,
           dist = Math.hypot(dx, dy) || 1,
+          r    = d.target.r || BASE_RADIUS / 3,
           tEnd = (dist - r) / dist;    // line ends at target circle
     return `M${d.source.x},${d.source.y}L${d.source.x + dx*tEnd},${d.source.y + dy*tEnd}`;
   };
@@ -213,7 +215,7 @@ links.forEach(l => {
 
 // eight slot angles (0°,45°,…)
 const slots       = Array.from({length:8}, (_,i)=>i*Math.PI/4);
-const labelRadius = 28;  // px from node center
+const labelOffset = 6;  // px beyond circle
 
 nodeSel.select('text').each(function(d){
   const edges = incident.get(d.id) || [];
@@ -226,8 +228,9 @@ nodeSel.select('text').each(function(d){
     if (score > bestScore){ bestScore = score; bestAng = s; }
   });
 
-  const tx = Math.cos(bestAng)*labelRadius,
-        ty = Math.sin(bestAng)*labelRadius;
+  const rLab = (d.r || BASE_RADIUS / 3) + labelOffset;
+  const tx = Math.cos(bestAng)*rLab,
+        ty = Math.sin(bestAng)*rLab;
 
   d3.select(this)
     .attr('x', tx)
@@ -273,6 +276,18 @@ nodeSel.select('text').each(function(d){
 }
 
 /* ---------- helpers ---------- */
+
+function updateNodeRadii() {
+  const counts = new Map(nodes.map(n => [n.id, 0]));
+  links.forEach(l => {
+    counts.set(l.id1, (counts.get(l.id1) || 0) + 1);
+    counts.set(l.id2, (counts.get(l.id2) || 0) + 1);
+  });
+  nodes.forEach(n => {
+    const c = counts.get(n.id) || 0;
+    n.r = BASE_RADIUS * Math.max(c, 1) / 3;
+  });
+}
 
 function formatNodeLabel(n){
   return (n.birth_year !== undefined && n.birth_year !== null && n.birth_year !== '')
@@ -377,6 +392,7 @@ function applyLayoutForces() {
 }
 
 function updateGraph(skipSelectUpdate = false, highlightIdx = null) {
+  updateNodeRadii();
   const simLinks = buildSimLinks();
 
   /* ---- links ---- */
@@ -446,13 +462,16 @@ nodeSel = g.selectAll('.node').data(nodes, d => d.id)
             d3.select(event.currentTarget).select('text').text(formatNodeLabel(d));
           });
 
-      nodeG.append('circle').attr('r', 22);
+      nodeG.append('circle').attr('r', d => d.r);
       nodeG.append('text')
            .attr('dominant-baseline', 'central')
            .text(d => formatNodeLabel(d));
       return nodeG;
     },
-    update => update.select('text').text(d => formatNodeLabel(d)),
+    update => {
+      update.select('text').text(d => formatNodeLabel(d));
+      update.select('circle').attr('r', d => d.r);
+    },
     exit   => exit.remove()
   );
 


### PR DESCRIPTION
## Summary
- resize nodes based on number of incident edges
- adjust collision radius and label offset accordingly
- recompute node radii whenever graph updates

## Testing
- `git status --short`