### PR TITLE
Update export UI and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ This script extends `http.server` so the page can upload images. The old
 `python -m http.server 8007` command will still serve the page read-only.
 Then open `http://localhost:8007/force.html` in your browser.
 
+After making changes in the page, copy the contents of the small data view in
+the lower-right corner.  It turns yellow when your edits are newer than the
+last copied text.
+
 ## Status
 
 Development is active. The repository now also contains:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Force-Sort Graph Editor
+
+This project is a minimal editor for an author relationship graph.  The page
+`force.html` displays a D3 force‑directed diagram and lets you add or edit
+nodes and edges directly in the browser.  Uploaded images are stored in the
+`images/` folder via `server.py` and referenced by the graph data file
+`data.json`.
+
+## Running
+
+Start the lightweight web server from the repository root:
+
+```bash
+python server.py
+```
+
+Then open [http://localhost:8007/force.html](http://localhost:8007/force.html)
+ in your browser.  The script allows image uploads, so using `python -m
+http.server` will only provide read‑only access.
+
+## Product Goals
+
+* **Simple editing.**  Nodes and edges can be created, deleted and renamed
+  without leaving the page.
+* **Copy‑to‑save workflow.**  All changes are reflected in the data view in the
+  bottom‑right corner.  The text area turns yellow whenever the data differs
+  from what you've copied.  Click the area to copy the JSON to your clipboard
+  and it turns white again.  Saving the clipboard contents back to
+  `data.json` is manual to avoid accidental loss.
+* **Image support.**  While a node editor popup is open you can paste an image.
+  It will be uploaded to the server and shown as the node's icon.
+* **Layout options.**  A "tiers" layout is available in addition to the default
+  force simulation.
+
+The application aims to remain single‑page and self‑contained.  Styling is kept
+minimal and everything is bundled inside `force.html` for easy hosting.
+

--- a/force.html
+++ b/force.html
@@ -12,9 +12,21 @@
     #topControls,#bottomControls{display:flex;gap:12px;padding:8px;flex-wrap:wrap}
     #topControls{border-bottom:1px solid #ddd}
     #bottomControls{border-top:1px solid #ddd}
-    #graph{width:100%;height:calc(100% - 260px)} /* two control bars + export */
+    #graph{width:100%;height:calc(100% - 120px)} /* two control bars */
 
-    textarea#export{position:fixed;bottom:0;left:0;width:100%;height:140px;border:none;resize:none;font-family:monospace;padding:8px;box-sizing:border-box;background:#f8f8f8}
+    textarea#export{
+      position:fixed;
+      bottom:10px;
+      right:10px;
+      width:240px;
+      height:160px;
+      border:1px solid #ccc;
+      resize:none;
+      font-family:monospace;
+      padding:6px;
+      box-sizing:border-box;
+      background:#fff;
+    }
     textarea#export.unsaved{background:#fff3c4}
 
     .node circle{fill:#a7d3ff;stroke:#fff;stroke-width:2px;cursor:grab}
@@ -379,7 +391,7 @@ exportArea.addEventListener('click', () => {
     .then(() => exportArea.classList.remove('unsaved'));
 });
 
-function refreshExport() {
+function refreshExport(markDirty = true) {
   exportArea.value = JSON.stringify({
     nodes: nodes.map(n => {
       const obj = { id: n.id, name: n.name };
@@ -389,7 +401,11 @@ function refreshExport() {
     }),
     links
   }, null, 2);
-  exportArea.classList.add("unsaved");
+  if (markDirty) {
+    exportArea.classList.add('unsaved');
+  } else {
+    exportArea.classList.remove('unsaved');
+  }
 }
 
 function computeTiers() {
@@ -418,7 +434,7 @@ function applyLayoutForces() {
   }
 }
 
-function updateGraph(skipSelectUpdate = false, highlightIdx = null) {
+function updateGraph(skipSelectUpdate = false, highlightIdx = null, markDirty = true) {
   const simLinks = buildSimLinks();
 
   /* ---- links ---- */
@@ -517,7 +533,7 @@ nodeSel = g.selectAll('.node').data(nodes, d => d.id)
            .transition().delay(10000)
            .on('end', function () { d3.select(this).classed('highlight', false); });
   }
-  refreshExport();
+  refreshExport(markDirty);
 }
 
 
@@ -752,7 +768,7 @@ addEdgeBtn.addEventListener('click', () => {
 /* ---------- initial render ---------- */
 loadData().then(() => {
   populateSelects();
-  updateGraph();
+  updateGraph(false, null, false);
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- move export data area to lower right and highlight on edits
- keep export data white on first load
- document workflow and product goals

## Testing
- `python -m py_compile server.py`