### PR TITLE
Enable automatic data save to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ http.server` will only provide read‑only access.
 * **Copy‑to‑save workflow.**  All changes are reflected in the data view in the
   bottom‑right corner.  The text area turns yellow whenever the data differs
   from what you've copied.  Click the area to copy the JSON to your clipboard
-  and it turns white again.  Saving the clipboard contents back to
-  `data.json` is manual to avoid accidental loss.
+  and it turns white again.  The page now also sends the data to
+  `server.py` each time it changes so it is written to `data.json`
+  automatically.  Previous versions are stored in the `backups/` folder.
 * **Image support.**  Each node can hold multiple images.  Paste or upload
   pictures while the editor popup is open, rearrange or remove them, and
   identical uploads are detected automatically.

--- a/force.html
+++ b/force.html
@@ -411,6 +411,14 @@ exportArea.addEventListener('click', () => {
     .then(() => exportArea.classList.remove('unsaved'));
 });
 
+function saveDataToServer(text){
+  fetch('/save_data', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: text
+  });
+}
+
 function refreshExport(markDirty = true) {
   exportArea.value = JSON.stringify({
     nodes: nodes.map(n => {
@@ -424,6 +432,7 @@ function refreshExport(markDirty = true) {
   }, null, 2);
   if (markDirty) {
     exportArea.classList.add('unsaved');
+    saveDataToServer(exportArea.value);
   } else {
     exportArea.classList.remove('unsaved');
   }


### PR DESCRIPTION
## Summary
- implement `/save_data` POST endpoint in `server.py`
- keep data backups before overwriting
- send data automatically from `force.html` when it changes
- document the new behavior in README

## Testing
- `python -m py_compile server.py`