### PR TITLE
Fix node image popup carryover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,5 @@ Development is active. The repository now also contains:
 - `images/` – uploaded image files.
 - `force.html` – the main page with inline JS and CSS.
 - `data.json` – the dataset consumed by the page.
+- Node editor popup now clears old images when switching between people so
+  the interface always shows the correct pictures.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ http.server` will only provide read‑only access.
 * **Image support.**  Each node can hold multiple images.  Paste or upload
   pictures while the editor popup is open, rearrange or remove them, and
   identical uploads are detected automatically.
+  The popup now reliably resets when switching between nodes so you never
+  see another person's pictures by mistake.
 * **Layout options.**  A "tiers" layout is available in addition to the default
   force simulation.
 

--- a/force.html
+++ b/force.html
@@ -715,10 +715,14 @@ function openNodePopup(id, x, y) {
   const n = nodeById.get(id);
   if (!n) return;
   nodePopupId = id;
+  nodePopupImages.innerHTML = '';
   nodePopupName.value = n.name || '';
   nodePopupYear.value = n.birth_year || '';
+  const curId = id;
   dedupeImages(n).then(()=>{
-    renderNodeImages(n);
+    if(nodePopupId === curId){
+      renderNodeImages(n);
+    }
   });
   nodePopup.style.left = (x + 5) + 'px';
   nodePopup.style.top  = (y + 5) + 'px';


### PR DESCRIPTION
## Summary
- clear node image popup when opening
- ignore asynchronous image rendering from old nodes
- document fix in README
- update AGENTS project notes

## Testing
- `python -m py_compile server.py`