### PR TITLE
Fix edge editing bugs

### DIFF
--- a/force.html
+++ b/force.html
@@ -204,7 +204,8 @@ function buildSimLinks(arr) {
     source : nodeById.get(e.id1),
     target : nodeById.get(e.id2),
     label  : e.label,
-    dir    : e.id1 < e.id2 ? 1 : -1    // A→B “up”, B→A “down”
+    dir    : e.id1 < e.id2 ? 1 : -1,   // A→B “up”, B→A “down”
+    link   : e                          // reference to original data
   }));
 }
 
@@ -266,7 +267,7 @@ const edgePopupSave   = document.getElementById('edgePopupSave');
 const edgePopupReverse= document.getElementById('edgePopupReverse');
 const edgePopupDelete = document.getElementById('edgePopupDelete');
 const edgePopupClose  = document.getElementById('edgePopupClose');
-let   edgePopupIndex  = null;
+let   edgePopupLink   = null;
 
 const nodePopup       = document.getElementById('nodePopup');
 const nodePopupName   = document.getElementById('nodePopupName');
@@ -634,6 +635,8 @@ function applyFocusFilter(restartSim = true){
   refreshLinks(restartSim);
   linkSel.classed('focus-edge', d => d.id1===focusNodeId || d.id2===focusNodeId);
   updateHiddenEdges();
+  focusRange.value = depth;
+  focusNum.textContent = depth;
 }
 
 function setupSearchAndFilter(){
@@ -667,7 +670,7 @@ function setupSearchAndFilter(){
 function refreshLinks(restartSim = true){
   const simLinks = buildSimLinks(visibleLinks);
 
-  linkSel = linkGroup.selectAll('path.link').data(simLinks, (d,i)=>i)
+  linkSel = linkGroup.selectAll('path.link').data(simLinks, d => links.indexOf(d.link))
         .join(
                 enter => enter.append('path')
                                           .attr('class','link')
@@ -683,7 +686,7 @@ function refreshLinks(restartSim = true){
                 exit   => exit.remove()
           );
 
-  linkHitSel = linkGroup.selectAll('path.link-hit').data(simLinks, (d,i)=>i)
+  linkHitSel = linkGroup.selectAll('path.link-hit').data(simLinks, d => links.indexOf(d.link))
         .join(
                 enter => enter.append('path')
                                           .attr('class','link-hit')
@@ -692,7 +695,7 @@ function refreshLinks(restartSim = true){
                 exit   => exit.remove()
           );
 
-  labelSel = linkGroup.selectAll('text.label').data(simLinks, (d,i)=>i)
+  labelSel = linkGroup.selectAll('text.label').data(simLinks, d => links.indexOf(d.link))
   .join(
     enter => enter.append('text')
                   .attr('class','label')
@@ -700,9 +703,7 @@ function refreshLinks(restartSim = true){
                   /* dbl-click label edit */
                   .on('dblclick', (event,d) => {
                     event.stopPropagation();
-                    const idx = labelSel.nodes().indexOf(event.currentTarget);
-                    if (idx === -1) return;
-                    openEdgePopup(idx, event.pageX, event.pageY);
+                    openEdgePopup(d.link, event.pageX, event.pageY);
                   })
                   .on('click', edgeMenu),
     update => update.text(d => d.label),
@@ -857,7 +858,7 @@ nodeSel = g.selectAll('.node').data(nodes, d => d.id)
 
   if (!skipSelectUpdate) populateSelects();
   if (highlightIdx !== null) {
-    linkSel.filter((d, i) => i === highlightIdx)
+    linkSel.filter(d => links.indexOf(d.link) === highlightIdx)
            .classed('highlight', true)
            .transition().delay(10000)
            .on('end', function () { d3.select(this).classed('highlight', false); });
@@ -869,9 +870,9 @@ nodeSel = g.selectAll('.node').data(nodes, d => d.id)
 }
 
 
-function openEdgePopup(idx, x, y) {
-  edgePopupIndex = idx;
-  edgePopupLabel.value = links[idx].label || '';
+function openEdgePopup(linkObj, x, y) {
+  edgePopupLink = linkObj;
+  edgePopupLabel.value = linkObj.label || '';
   edgePopup.style.left = (x + 5) + 'px';
   edgePopup.style.top  = (y + 5) + 'px';
   edgePopup.style.display = 'block';
@@ -880,17 +881,13 @@ function openEdgePopup(idx, x, y) {
 function edgeMenu(event, d) {
   if (event.detail > 1) return; // ignore double-click
   event.stopPropagation();
-  let idx = linkSel.nodes().indexOf(event.currentTarget);
-  if (idx === -1) idx = labelSel.nodes().indexOf(event.currentTarget);
-  if (idx === -1) idx = linkHitSel.nodes().indexOf(event.currentTarget);
-  if (idx === -1) return;
-
-  openEdgePopup(idx, event.pageX, event.pageY);
+  if (!d || !d.link) return;
+  openEdgePopup(d.link, event.pageX, event.pageY);
 }
 
 function hideEdgePopup() {
   edgePopup.style.display = 'none';
-  edgePopupIndex = null;
+  edgePopupLink = null;
 }
 
 function deleteImageFile(id, path){
@@ -1026,15 +1023,15 @@ nodePopupClose.addEventListener('click', e => {
 
 edgePopupSave.addEventListener('click', e => {
   e.stopPropagation();
-  if (edgePopupIndex === null) return;
-  links[edgePopupIndex].label = edgePopupLabel.value;
+  if (!edgePopupLink) return;
+  edgePopupLink.label = edgePopupLabel.value;
   hideEdgePopup();
   updateGraph();
 });
 edgePopupReverse.addEventListener('click', e => {
   e.stopPropagation();
-  if (edgePopupIndex === null) return;
-  const l = links[edgePopupIndex];
+  if (!edgePopupLink) return;
+  const l = edgePopupLink;
   [l.id1, l.id2] = [l.id2, l.id1];
   hideEdgePopup();
   if(focusNodeId !== null){
@@ -1047,8 +1044,9 @@ edgePopupReverse.addEventListener('click', e => {
 });
 edgePopupDelete.addEventListener('click', e => {
   e.stopPropagation();
-  if (edgePopupIndex === null) return;
-  links.splice(edgePopupIndex, 1);
+  if (!edgePopupLink) return;
+  const idx = links.indexOf(edgePopupLink);
+  if (idx !== -1) links.splice(idx, 1);
   hideEdgePopup();
   updateGraph();
 });


### PR DESCRIPTION
## Summary
- track link objects instead of indexes when opening edge popups
- update DOM binding to use link references
- keep focus range slider synced when focus filter reapplies
- adjust highlight logic for new binding

## Testing
- `python -m py_compile server.py`
- `python -m json.tool data.json >/tmp/validated.json && rm /tmp/validated.json`
