### PR TITLE
Fix filter persistence when editing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ Development is active. The repository now also contains:
 - `data.json` – the dataset consumed by the page.
 - Node editor popup now clears old images when switching between people so
   the interface always shows the correct pictures.
+- Focus and year filters persist through node or edge updates. These states only
+  change when the filter controls themselves are used.
 
 ## Repository Overview
 This section summarizes the purpose of each file and folder in the project.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The popup now reliably resets when switching between nodes so you never
 * **Layout options.**  A "tiers" layout is available in addition to the default
   force simulation. A new "force+direction" mode keeps edges mostly pointing
   downward while still using forces.
+* **Filter persistence.**  Active focus or year filters stay applied while you
+  edit nodes or edges. The selected filters only change when you interact with
+  the filter controls themselves.
 
 ## Data Format
 

--- a/force.html
+++ b/force.html
@@ -652,7 +652,12 @@ function setupSearchAndFilter(){
       tooltips:true,
       format:{to:v=>Math.round(v), from:v=>+v}
     });
-    yearSlider.noUiSlider.on('update', applyYearFilter);
+    yearSlider.noUiSlider.on('update', () => {
+      applyYearFilter();
+      if(focusNodeId !== null){
+        applyFocusFilter();
+      }
+    });
   } else {
     yearSlider.style.display = 'none';
   }
@@ -756,7 +761,12 @@ function setupSearchAndFilter(){
       tooltips:true,
       format:{to:v=>Math.round(v), from:v=>+v}
     });
-    yearSlider.noUiSlider.on('update', applyYearFilter);
+    yearSlider.noUiSlider.on('update', () => {
+      applyYearFilter();
+      if(focusNodeId !== null){
+        applyFocusFilter();
+      }
+    });
   } else {
     yearSlider.style.display = 'none';
   }
@@ -864,8 +874,8 @@ nodeSel = g.selectAll('.node').data(nodes, d => d.id)
            .on('end', function () { d3.select(this).classed('highlight', false); });
   }
   refreshExport(markDirty);
-  applyFocusFilter();
   applyYearFilter();
+  applyFocusFilter();
   highlightSearch();
 }
 


### PR DESCRIPTION
## Summary
- preserve active filters when the year slider updates
- run year filter before focus filter when redrawing
- document filter persistence in README and AGENTS

## Testing
- `python -m py_compile server.py`
- `python -m json.tool data.json > /dev/null`