### PR TITLE
Enforce CRLF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+end_of_line = crlf
+charset = utf-8

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Ensure consistent line endings
+* text eol=crlf
+
+# Treat image files as binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,4 +92,6 @@ Example snippet:
 To avoid churn from inconsistent line endings, use **CRLF** (`\r\n`) line
 terminators for all files in this repository. Configure your editor to save
 files with Windows line endings and do not convert them to plain `\r` or
-other styles.
+other styles. Line endings are automatically enforced by the repository's
+`.gitattributes` and `.editorconfig` files so most editors will handle them
+correctly without extra setup.

--- a/README.md
+++ b/README.md
@@ -52,3 +52,9 @@ an `id`, a `name`, an optional `birth_year`, and an `images` array. The
 The application aims to remain single‑page and self‑contained.  Styling is kept
 minimal and everything is bundled inside `force.html` for easy hosting.
 
+## Line Endings
+
+All text files use **CRLF** (`\r\n`) line terminators. The repository includes
+`.gitattributes` and `.editorconfig` files so Git and common editors enforce this
+automatically. No additional setup is required.
+


### PR DESCRIPTION
## Summary
- add `.gitattributes` with text eol rules
- add `.editorconfig` for editor support
- document line ending setup in README
- clarify contribution guidelines in AGENTS

## Testing
- `git status --short`